### PR TITLE
add exceptions for Goal

### DIFF
--- a/src/main/java/life/calgo/logic/commands/GoalCommand.java
+++ b/src/main/java/life/calgo/logic/commands/GoalCommand.java
@@ -18,6 +18,15 @@ public class GoalCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Successfully updated your daily caloric goal to %1$d.";
 
+    public static final String MESSAGE_FAILURE_TYPE = "Please key in a non-zero whole number for your "
+            + "daily caloric goal.";
+
+    public static final String MESSAGE_FAILURE_NEGATIVE = "Please key in a positive whole number for your "
+            + "daily caloric goal.";
+
+    public static final String MESSAGE_WARNING = "That is a really low goal to set. Warning: You may suffer from"
+            + " malnutrition. Don't worry! Calgo is here to help you build healthier eating habits.";
+
     private final int numCaloriesDaily;
 
     public GoalCommand(int numberCaloriesDaily) {
@@ -28,6 +37,9 @@ public class GoalCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateDailyGoal(this.numCaloriesDaily);
+        if (this.numCaloriesDaily <= 1000) {
+            return new CommandResult(MESSAGE_WARNING);
+        }
         return new CommandResult(String.format(MESSAGE_SUCCESS, numCaloriesDaily));
     }
 

--- a/src/main/java/life/calgo/logic/parser/GoalCommandParser.java
+++ b/src/main/java/life/calgo/logic/parser/GoalCommandParser.java
@@ -10,8 +10,8 @@ import life.calgo.logic.parser.exceptions.ParseException;
 public class GoalCommandParser implements Parser<GoalCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the GoalCommand
-     * and returns a GoalCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * and returns a GoalCommand object for execution
+     * @throws ParseException if the user input does not conform the expected format or is less than or equal to 0
      */
     public GoalCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
@@ -25,10 +25,12 @@ public class GoalCommandParser implements Parser<GoalCommand> {
         try {
             targetCalories = Integer.parseInt(splitArgs[1]);
         } catch (NumberFormatException e) {
-            throw new ParseException(
-                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, GoalCommand.MESSAGE_USAGE)
-            );
+            throw new ParseException(GoalCommand.MESSAGE_FAILURE_TYPE);
         }
+        if (targetCalories <= 0) {
+            throw new ParseException(GoalCommand.MESSAGE_FAILURE_NEGATIVE);
+        }
+
         return new GoalCommand(targetCalories);
     }
 }


### PR DESCRIPTION
Calgo no longer accepts non-positive goals. It still accepts low goals but provides warning message.